### PR TITLE
added a container when renderInsideForm is false

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "babel-cli": "6.5.1",
     "babel-eslint": "^5.0.0",
+    "babel-jest": "^15.0.0",
     "babel-polyfill": "^6.5.0",
     "babel-preset-es2015": "6.5.0",
     "babel-preset-react": "^6.5.0",
@@ -34,6 +35,7 @@
     "brfs": "^1.4.3",
     "browserify": "^13.0.0",
     "budo": "^8.0.3",
+    "enzyme": "^2.4.1",
     "eslint": "^1.10.3",
     "eslint-plugin-react": "^3.16.1",
     "jest-cli": "^15.1.1",

--- a/src/form.js
+++ b/src/form.js
@@ -389,6 +389,17 @@ export default class Form extends React.Component {
     this.setState({ errorMessages })
   }
 
+  isRN () {
+    let isNative = false;
+    try {
+      let Platform = require('react-native').Platform;
+      if (Platform) {
+        isNative = true;
+      };
+    } catch(e) {}
+    return isNative;
+  }
+
   onValueChange (fieldName, newValue) {
     //  newValue = typeof newValue === 'undefined' ? null : newValue
     DotObject.del(fieldName, this.state.doc)
@@ -445,7 +456,11 @@ export default class Form extends React.Component {
         </form>
       )
     } else {
-      return <div>{this.renderInsideForm()}</div>
+      if (this.isRN()) {
+        return this.renderInsideForm()
+      } else {
+        return <div>{this.renderInsideForm()}</div>
+      }
     }
   }
 }

--- a/src/form.js
+++ b/src/form.js
@@ -445,7 +445,7 @@ export default class Form extends React.Component {
         </form>
       )
     } else {
-      return this.renderInsideForm()
+      return <div>{this.renderInsideForm()}</div>
     }
   }
 }

--- a/src/form.test.js
+++ b/src/form.test.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { shallow, mount, render } from 'enzyme';
+import Form from './form';
+
+test('Should render by default a <form>', () => {
+  const component = shallow(
+    <Form>
+      <div>dummy</div>
+    </Form>
+  );
+  expect(component.find('form').length).toBe(1);
+});
+
+test('Should not render a <form> if useFormTag is false', () => {
+  const component = shallow(
+    <Form useFormTag={false}>
+      <div>dummy</div>
+    </Form>
+  );
+  expect(component.find('form').length).toBe(0);
+});


### PR DESCRIPTION
Right now, if you try to use `renderInsideForm={false}`, you get a render error. This is caused because on the first run, `this.renderInsideForm()` is returning null.

With a container, this bug is fixed.