### PR TITLE
Fix array item removal

### DIFF
--- a/src/Array/index.test.tsx
+++ b/src/Array/index.test.tsx
@@ -66,6 +66,27 @@ it('removeItem should remove the item', () => {
   expect(container.querySelector('.children')).not.toBeInTheDocument()
 })
 
+it('removeItem should only remove the clicked item when duplicates exist', () => {
+  let state = {items: [{name: 'dup'}, {name: 'dup'}]}
+
+  const {container} = render(
+    <Form state={state} onChange={changes => (state = changes)}>
+      <Field fieldName="items" type={ArrayField}>
+        <Field fieldName="name" type={DummyInput} />
+      </Field>
+    </Form>,
+  )
+
+  const removeButtons = container.querySelectorAll('.srf_removeButton')
+  fireEvent.click(removeButtons[0])
+
+  act(() => {
+    jest.advanceTimersByTime(0)
+  })
+
+  expect(state).toEqual({items: [{name: 'dup'}]})
+})
+
 it('should render an error if there is one', () => {
   const {container} = render(
     <Form>

--- a/src/Array/index.tsx
+++ b/src/Array/index.tsx
@@ -106,7 +106,8 @@ export default class ArrayComponent extends React.Component<
 
   removeItem(index) {
     const value = this.props.value || []
-    var newArray = without(value, value[index])
+    const newArray = value.slice()
+    newArray.splice(index, 1)
     this.props.onChange(newArray)
   }
 


### PR DESCRIPTION
## Summary
- fix `ArrayComponent.removeItem` so only the selected index is removed
- add regression test for removing duplicates from an array

## Testing
- `yarn test` *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_683f41affd0483288ad5be0e2f29508f